### PR TITLE
📖 [Docs]: Rename module to `CasingStyle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ Get-Help ConvertTo-CasingStyle -Examples
 
 For further documentation, please visit the official documentation pages for each function:
 
-- [ConvertTo-CasingStyle](https://psmodule.io/Casing/Functions/ConvertTo-CasingStyle/)
-- [Get-CasingStyle](https://psmodule.io/Casing/Functions/Get-CasingStyle/)
-- [Split-CasingStyle](https://psmodule.io/Casing/Functions/Split-CasingStyle/)
+- [ConvertTo-CasingStyle](https://psmodule.io/CasingStyle/Functions/ConvertTo-CasingStyle/)
+- [Get-CasingStyle](https://psmodule.io/CasingStyle/Functions/Get-CasingStyle/)
+- [Split-CasingStyle](https://psmodule.io/CasingStyle/Functions/Split-CasingStyle/)
 
 ## Contributing
 

--- a/src/functions/public/ConvertTo-CasingStyle.ps1
+++ b/src/functions/public/ConvertTo-CasingStyle.ps1
@@ -23,7 +23,7 @@
         [string] - The converted string
 
         .LINK
-        https://psmodule.io/Casing/Functions/ConvertTo-CasingStyle/
+        https://psmodule.io/CasingStyle/Functions/ConvertTo-CasingStyle/
     #>
     [OutputType([string])]
     [CmdletBinding()]

--- a/src/functions/public/Get-CasingStyle.ps1
+++ b/src/functions/public/Get-CasingStyle.ps1
@@ -60,7 +60,7 @@
         [string] - The detected casing style of the input string
 
         .LINK
-        https://psmodule.io/Casing/Functions/Get-CasingStyle/
+        https://psmodule.io/CasingStyle/Functions/Get-CasingStyle/
     #>
     [OutputType([string])]
     [CmdletBinding()]

--- a/src/functions/public/Split-CasingStyle.ps1
+++ b/src/functions/public/Split-CasingStyle.ps1
@@ -61,7 +61,7 @@
         [string[]] - An array of strings, each representing a word in the original string
 
         .LINK
-        https://psmodule.io/Casing/Functions/Split-CasingStyle/
+        https://psmodule.io/CasingStyle/Functions/Split-CasingStyle/
     #>
     [CmdletBinding()]
     param(

--- a/tests/Casing.Tests.ps1
+++ b/tests/Casing.Tests.ps1
@@ -1,4 +1,4 @@
-﻿Describe 'Casing' {
+﻿Describe 'CasingStyle' {
     Context 'Function: Get-CasingStyle' {
         It "Get-CasingStyle: Detects 'testtesttest' as lowercase" {
             'testtesttest' | Get-CasingStyle | Should -Be 'lowercase'


### PR DESCRIPTION
## Description

This pull request includes updates to URLs and test descriptions to ensure consistency with the name change to `CasingStyle`.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L98-R100): Updated URLs for `ConvertTo-CasingStyle`, `Get-CasingStyle`, and `Split-CasingStyle` to reflect the correct paths.
* [`src/functions/public/ConvertTo-CasingStyle.ps1`](diffhunk://#diff-258b23af5ee150cb504dd0c5ae9ca077838800780474332a2bdca6831e5e7ba0L26-R26): Updated the `.LINK` URL to the correct path.
* [`src/functions/public/Get-CasingStyle.ps1`](diffhunk://#diff-95b4ce37b8898c19567d7a2598dc12aa9e21c40f97459f2883b6dafc14c9b063L63-R63): Updated the `.LINK` URL to the correct path.
* [`src/functions/public/Split-CasingStyle.ps1`](diffhunk://#diff-fc6326239979c77a5e409ef744f5c3c80f517308d5fa4489f08c0a46d617bcd2L64-R64): Updated the `.LINK` URL to the correct path.

Test updates:

* [`tests/Casing.Tests.ps1`](diffhunk://#diff-2f2303af7c9cde9c678233849880c4fbbd3a657ae65db7ee89ccdf0e659d373bL1-R1): Changed the test description context from 'Casing' to 'CasingStyle' for consistency.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
