### PR TITLE
📖 [Docs]: README pages now use the standard module landing-page format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # CasingStyle
 
-CasingStyle is a PowerShell module for working with text casing styles.
+CasingStyle is a PowerShell module for detecting, converting, and splitting text casing styles. It is handy for text transformations,
+standardizing variable names, and keeping formatting consistent across scripts.
 
 ## Installation
 
@@ -9,6 +10,44 @@ Install the module from the PowerShell Gallery:
 ```powershell
 Install-PSResource -Name CasingStyle
 Import-Module -Name CasingStyle
+```
+
+## Usage
+
+### Example: Convert a string to a different casing style
+
+```powershell
+'thisIsCamelCase' | ConvertTo-CasingStyle -To 'snake_case'
+# Output: this_is_camel_case
+
+'thisIsCamelCase' | ConvertTo-CasingStyle -To 'UPPER_SNAKE_CASE'
+# Output: THIS_IS_CAMEL_CASE
+
+'thisIsCamelCase' | ConvertTo-CasingStyle -To 'kebab-case'
+# Output: this-is-camel-case
+```
+
+### Example: Detect the casing style of a string
+
+```powershell
+'testTestTest' | Get-CasingStyle
+# Output: camelCase
+
+'TestTestTest' | Get-CasingStyle
+# Output: PascalCase
+```
+
+### Example: Split a string based on casing style
+
+```powershell
+Split-CasingStyle -Text 'this-is-a-kebab-case-string' -By 'kebab-case'
+# Output:
+# this
+# is
+# a
+# kebab
+# case
+# string
 ```
 
 ## Documentation
@@ -21,7 +60,3 @@ Use PowerShell help and command discovery for module details:
 Get-Command -Module CasingStyle
 Get-Help Get-CasingStyle -Examples
 ```
-
-## Contributing
-
-Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.

--- a/README.md
+++ b/README.md
@@ -1,115 +1,27 @@
 # CasingStyle
 
-The `CasingStyle` PowerShell module provides functions for detecting, converting, and splitting different casing styles in strings. This can be
-useful for text transformations, standardizing variable names, and ensuring consistent formatting in scripts.
-
-## Prerequisites
-
-This module does not require additional dependencies, but it integrates well with the [PSModule framework](https://github.com/PSModule) for building,
-testing, and publishing PowerShell modules.
+CasingStyle is a PowerShell module for working with text casing styles.
 
 ## Installation
 
-To install the module from the PowerShell Gallery, you can use the following command:
+Install the module from the PowerShell Gallery:
 
 ```powershell
 Install-PSResource -Name CasingStyle
 Import-Module -Name CasingStyle
 ```
 
-## Usage
-
-The following examples demonstrate common use cases for the module, showing how it can be applied to detect, convert, and manipulate different casing
-styles in strings.
-
-### Example 1: Convert a string to a different casing style
-
-```powershell
-'thisIsCamelCase' | ConvertTo-CasingStyle -To 'snake_case'
-# Output: this_is_camel_case
-```
-
-```powershell
-'thisIsCamelCase' | ConvertTo-CasingStyle -To 'UPPER_SNAKE_CASE'
-# Output: THIS_IS_CAMEL_CASE
-```
-
-```powershell
-'thisIsCamelCase' | ConvertTo-CasingStyle -To 'kebab-case'
-# Output: this-is-camel-case
-```
-
-### Example 2: Detect the casing style of a string
-
-```powershell
-'testTestTest' | Get-CasingStyle
-# Output: camelCase
-```
-
-```powershell
-'TestTestTest' | Get-CasingStyle
-# Output: PascalCase
-```
-
-### Example 3: Split a string based on casing style
-
-```powershell
-Split-CasingStyle -Text 'this-is-a-kebab-case-string' -By 'kebab-case'
-# Output:
-# this
-# is
-# a
-# kebab
-# case
-# string
-```
-
-```powershell
-Split-CasingStyle -Text 'ThisIsAPascalCaseString' -By 'PascalCase'
-# Output:
-# This
-# Is
-# A
-# Pascal
-# Case
-# String
-```
-
-### Find more examples
-
-To find more examples of how to use the module, please refer to the [examples](examples) folder.
-
-Alternatively, you can use the following PowerShell commands:
-
-```powershell
-Get-Command -Module 'CasingStyle'
-```
-
-To find examples of each of the commands, you can use:
-
-```powershell
-Get-Help ConvertTo-CasingStyle -Examples
-```
-
 ## Documentation
 
-For further documentation, please visit the official documentation pages for each function:
+Documentation is published at [psmodule.io/CasingStyle](https://psmodule.io/CasingStyle/).
 
-- [ConvertTo-CasingStyle](https://psmodule.io/CasingStyle/Functions/ConvertTo-CasingStyle/)
-- [Get-CasingStyle](https://psmodule.io/CasingStyle/Functions/Get-CasingStyle/)
-- [Split-CasingStyle](https://psmodule.io/CasingStyle/Functions/Split-CasingStyle/)
+Use PowerShell help and command discovery for module details:
+
+```powershell
+Get-Command -Module CasingStyle
+Get-Help <CommandName> -Examples
+```
 
 ## Contributing
 
-Regardless of your experience level, your contributions are valuable! Whether you're a beginner or an expert, you can help improve this project by
-sharing feedback, reporting issues, or contributing code.
-
-### For Users
-
-If you encounter unexpected behavior, errors, or missing functionality, you can help by submitting bug reports and feature requests.
-Please see the issues tab on this project and submit a new issue that describes your experience.
-
-### For Developers
-
-If you write code, we'd love to have your contributions! Please read the [Contribution guidelines](CONTRIBUTING.md) for more information.
-You can either help by picking up an existing issue or submit a new one if you have an idea for a new feature or improvement.
+Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use PowerShell help and command discovery for module details:
 
 ```powershell
 Get-Command -Module CasingStyle
-Get-Help <CommandName> -Examples
+Get-Help Get-CasingStyle -Examples
 ```
 
 ## Contributing


### PR DESCRIPTION
The `CasingStyle` README is now a concise landing page that follows the standard PSModule format, so users get a clear path from install to real usage without wading through duplicated command reference.

## What changed

- Restored a `## Usage` showcase with three realistic examples using the module's exported commands: convert a string between casing styles (`ConvertTo-CasingStyle`), detect a string's casing style (`Get-CasingStyle`), and split a string by casing style (`Split-CasingStyle`).
- Kept `## Installation` on `Install-PSResource` and a `## Documentation` section that points to [psmodule.io/CasingStyle](https://psmodule.io/CasingStyle/) plus `Get-Command` / `Get-Help` discovery using a real command.
- Removed the `## Contributing` section (community/contribution flow lives outside the published landing page).

## Notes

- Updates `README.md` only.
- Section order matches the standard: title → overview → Installation → Usage → Documentation.
